### PR TITLE
merge: integrate feature/create-user into main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/studyrats/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/studyrats/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.studyrats.api.exception;
+
+import com.studyrats.domain.exception.EmailAlreadyUsedException;
+import com.studyrats.domain.exception.UserValidationException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 400 Bad Request para DTOs inválidos
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationErrors(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fe.getField(), fe.getDefaultMessage());
+        }
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    // 400 para bean validation de parâmetros ou path variables
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String, String>> handleConstraintViolation(ConstraintViolationException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getConstraintViolations().forEach(cv ->
+                errors.put(cv.getPropertyPath().toString(), cv.getMessage())
+        );
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    // 500 Internal Server Error fallback
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleAllOther(Exception ex) {
+        ex.printStackTrace(); // opcional: log
+        Map<String, String> error = Map.of("error", "Internal server error");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    // 409 Conflict para email duplicado
+    @ExceptionHandler(EmailAlreadyUsedException.class)
+    public ResponseEntity<Map<String, String>> handleEmailInUse(EmailAlreadyUsedException ex) {
+        Map<String, String> error = Map.of("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    @ExceptionHandler(UserValidationException.class)
+    public ResponseEntity<Map<String,String>> handleUserValidation(UserValidationException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", ex.getMessage()));
+    }
+
+}

--- a/src/main/java/com/studyrats/domain/exception/EmailAlreadyUsedException.java
+++ b/src/main/java/com/studyrats/domain/exception/EmailAlreadyUsedException.java
@@ -1,0 +1,7 @@
+package com.studyrats.domain.exception;
+
+public class EmailAlreadyUsedException extends UserValidationException {
+    public EmailAlreadyUsedException(String email) {
+        super("Email already in use: " + email);
+    }
+}

--- a/src/main/java/com/studyrats/domain/exception/UserValidationException.java
+++ b/src/main/java/com/studyrats/domain/exception/UserValidationException.java
@@ -1,0 +1,7 @@
+package com.studyrats.domain.exception;
+
+public abstract class UserValidationException extends RuntimeException {
+    protected UserValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/studyrats/domain/service/UserDomainService.java
+++ b/src/main/java/com/studyrats/domain/service/UserDomainService.java
@@ -1,5 +1,6 @@
 package com.studyrats.domain.service;
 
+import com.studyrats.domain.exception.EmailAlreadyUsedException;
 import com.studyrats.domain.model.User;
 import com.studyrats.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,9 @@ public class UserDomainService {
     private final UserRepository userRepository;
 
     public User create (User user) {
+        if (userRepository.findByEmail(user.getEmail()).isPresent()) {
+            throw new EmailAlreadyUsedException(user.getEmail());
+        }
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
This merge brings into main the complete implementation of the create-user feature:

- DTO validation with Bean Validation annotations
- User domain model, repository interface, and domain service with email-duplication check
- JPA UserEntity, SpringDataUserRepository, and JpaUserRepository implementation
- MapStruct mappers (UserEntityMapper, UserMapper)
- Application service orchestration (UserApplicationService)
- REST controller (UserController) with POST /users and Location header
- GlobalExceptionHandler for validation and domain errors
- Custom exceptions: UserValidationException and EmailAlreadyUsedException